### PR TITLE
Feature/nrldelete

### DIFF
--- a/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
+++ b/src/Hl7.Fhir.Core/Hl7.Fhir.Core.csproj
@@ -62,6 +62,9 @@
     <ProjectReference Include="..\..\common\src\Hl7.FhirPath\Hl7.FhirPath.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Hl7.Fhir.Core/Rest/FhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/FhirClient.cs
@@ -507,13 +507,13 @@ namespace Hl7.Fhir.Rest
         /// </summary>
         /// <param name="resourceType">The type of resource to delete</param>
         /// <param name="condition">Criteria to use to match the resource to delete.</param>
-        public async System.Threading.Tasks.Task DeleteAsync(string resourceType, SearchParams condition)
+        public async System.Threading.Tasks.Task DeleteAsync(string resourceType, SearchParams condition, bool decodedURL = false)
         {
             if (resourceType == null) throw Error.ArgumentNull(nameof(resourceType));
             if (condition == null) throw Error.ArgumentNull(nameof(condition));
 
             var tx = new TransactionBuilder(Endpoint).Delete(resourceType, condition).ToBundle();
-            await executeAsync<Resource>(tx,new[]{ HttpStatusCode.OK, HttpStatusCode.NoContent}).ConfigureAwait(false);
+            await executeAsync<Resource>(tx,new[]{ HttpStatusCode.OK, HttpStatusCode.NoContent}, decodedURL).ConfigureAwait(false);
         }
         /// <summary>
         /// Conditionally delete a resource
@@ -1059,12 +1059,12 @@ namespace Hl7.Fhir.Rest
             return executeAsync<TResource>(tx,  expect).WaitResult();
         }
 
-        private async Task<TResource> executeAsync<TResource>(Bundle tx, IEnumerable<HttpStatusCode> expect) where TResource : Resource
+        private async Task<TResource> executeAsync<TResource>(Bundle tx, IEnumerable<HttpStatusCode> expect, bool decodedURL = false) where TResource : Resource
         {
             verifyServerVersion();
 
             var request = tx.Entry[0];
-            var response = await _requester.ExecuteAsync(request).ConfigureAwait(false);
+            var response = await _requester.ExecuteAsync(request, decodedURL).ConfigureAwait(false);
 
             if (!expect.Select(sc => ((int)sc).ToString()).Contains(response.Response.Status))
             {

--- a/src/Hl7.Fhir.Core/Rest/IFhirClient.cs
+++ b/src/Hl7.Fhir.Core/Rest/IFhirClient.cs
@@ -43,7 +43,7 @@ namespace Hl7.Fhir.Rest
         void Delete(Uri location);
         System.Threading.Tasks.Task DeleteAsync(Resource resource);
         System.Threading.Tasks.Task DeleteAsync(string location);
-        System.Threading.Tasks.Task DeleteAsync(string resourceType, SearchParams condition);
+        System.Threading.Tasks.Task DeleteAsync(string resourceType, SearchParams condition, bool decodedURL = false);
         System.Threading.Tasks.Task DeleteAsync(Uri location);
         Task<TResource> executeAsync<TResource>(Bundle tx, HttpStatusCode expect) where TResource : Resource;
         Resource Get(string url);

--- a/src/Hl7.Fhir.Core/Rest/Requester.cs
+++ b/src/Hl7.Fhir.Core/Rest/Requester.cs
@@ -64,7 +64,7 @@ namespace Hl7.Fhir.Rest
         {
             return ExecuteAsync(interaction).WaitResult();
         }
-        public async Task<Bundle.EntryComponent> ExecuteAsync(Bundle.EntryComponent interaction)
+        public async Task<Bundle.EntryComponent> ExecuteAsync(Bundle.EntryComponent interaction, bool decodedURL = false)
         {
             if (interaction == null) throw Error.ArgumentNull(nameof(interaction));
             bool compressRequestBody = false;
@@ -73,7 +73,7 @@ namespace Hl7.Fhir.Rest
 
             byte[] outBody;
 
-            var request = interaction.ToHttpRequest(BaseUrl, this.PreferredParameterHandling, this.PreferredReturn, PreferredFormat, UseFormatParameter, compressRequestBody, out outBody);
+            var request = interaction.ToHttpRequest(BaseUrl, this.PreferredParameterHandling, this.PreferredReturn, PreferredFormat, UseFormatParameter, compressRequestBody, out outBody, decodedURL);
 
 #if !NETSTANDARD1_1
             request.Timeout = Timeout;


### PR DESCRIPTION
Adding Uri decoding support to EntryToHttpExtensions.ToHttpRequest to support NRL TKW Delete operation that is failing due to an encoded query string.